### PR TITLE
Standalone Registration Page

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,88 +20,18 @@ You can install this module with composer:
 
 How to setup the webauthn module
 -----------------------------------------
-You need to enable and configure the module's authprocfilter at a priority level
-so that it takes place AFTER the first-factor authentication. E.g. at 100:
+You need to enable the module's authprocfilter at a priority level
+so that it takes place AFTER the first-factor authentication. E.g. at 100 and
+if standalone registration and name2oid are used together, then the WebAuthn
+ auth proc filter has to run after name2oid.
 
 ```php
-100 => 
-    ['class' => 'webauthn:WebAuthn',
-
-    /* required configuration parameters */
-
-        'store' => [
-            'webauthn:Database',
-            'database.dsn' => 'mysql:host=db.example.org;dbname=fido2',
-            'database.username' => 'simplesaml',
-            'database.password' => 'sdfsdf',
-        ],
-        
-    'attrib_username' => 'urn:oid:1.3.6.1.4.1.23735.100.0',
-    'attrib_displayname' => 'urn:oid:2.5.4.3',
-
-    /* optional configuration parameters */
-
-    /* FIDO2 is phishing-resistent by binding generated credentials to a scope.
-     * Browsers will only invoke the registration/authentication if the scope
-     * matches the principal domain name the user is currently visiting.
-     * If not specified, the scope will be the hostname of the IdP as per 
-     * its metadata. It is permissible to widen the scope up to the prinicpal
-     * domain though (e.g. authentication service is "saml.example.com" => scope
-     * can be extended to "example.com"; but not "examp1e.com". A registered
-     * FIDO2 token can then also be used on other servers in the same domain.
-     * If configuring this item, be sure that the authentication server name and
-     * the desired scope are a suffix match.
-     * 
-     * If you do not control the entirety of your second-level domain, you must
-     * set the scope here explicitly to your own hostname to prevent some 
-     * contrived attack scenarios with other servers in that same second-level
-     * domain.
-     */
-    'scope' => 'example.com',
-
-    /* the following will interactively ask the user if he is willing to share
-     * manufacturer and model information during credential registration. 
-     * The user can decline, in which case registration will still succeed but
-     * vendor and model will be logged as "unknown model [unknown vendor]"
-     *
-     * When not requesting this, there is one less user interaction during the
-     * registration process; and no model information will be saved.
-     *
-     * defaults to "false"
-     */
-    'request_tokenmodel' => true,
-
-    /* should FIDO2 be enabled by default for all users? If not, users need to
-     * be white-listed in the database - other users simply pass through the
-     * filter without being subjected to 2FA.
-     *
-     * defaults to "disabled by default" === false
-     */
-    'default_enable' => false,
-
-    /* this parameter is used only if "use_database" is false. If the value of
-     * "force" is true then we trigger WebAuthn only if "attrib_toggle" from the
-     * user is not empty. If the value of "force" is false then we switch the value of
-     * "default_enable" only if "attrib_toggle" from the user is not empty.
-     * Default falue is true.
-     */
-     'force' => true,
-
-    /* this parameter stores the name of the attribute that is sent with user and which
-     * determines whether to trigger WebAuthn.
-     * Default value is 'toggle'
-     */
-     'attrib_toggle' => 'toggle',
-
-    /* this parameter determines if the database will be used to check
-     * whether to trigger second factor authentication or use the "attrib_toggle" instead. 
-     * Default value of this attribute is true
-     */
-    'use_database' => true,
-
-
+100 => [
+        'class' => 'webauthn:WebAuthn',
     ],
 ```
+Then you need to copy config-templates/module_webauthn.php to your config directory
+ and adjust settings accordingly. See the file for parameters description.
 
 Using storage
 -------------
@@ -197,6 +127,9 @@ Options
 `use_database`
 :    This parameter determines if the database will be used to check whether to trigger second factor authentication or use the "attrib_toggle" instead. Default value of this attribute is true.
 
+`use_inflow_registration`
+:    Optional parameter which determines whether you will be able to register and manage tokens while authenticating or you want to use the standalone registration page for these purposes. If set to false => standalone registration page, if true => inflow registration. If this parameter is not explicitly set, the value is considered to be true.
+
 User Experience / Workflow
 --------------------------
 Users for which WebAuthn is enabled cannot continue without a FIDO2 token. The
@@ -222,6 +155,10 @@ As long as a user account has 0 tokens there is no benefit yet; it's effectively
 still single factor authentication because anyone with the user's password can 
 register any token. That is in the nature of things. It could be avoided with
 an out-of-band registration process (in the same scope).
+
+If the standalone registration page is used, the user can't optionally enroll and manage tokens while logging in.
+The standalone registration page can be found under webauthn/registration.php, it requires authentication
+and after that you are redirected to a page where you can manage tokens.
 
 Device model detection
 ----------------------

--- a/config-templates/module_webauthn.php
+++ b/config-templates/module_webauthn.php
@@ -1,0 +1,86 @@
+<?php
+
+$config = [
+    /* required configuration parameters */
+    'store' => [
+        'webauthn:Database',
+        'database.dsn' => 'mysql:host=db.example.org;dbname=fido2',
+        'database.username' => 'simplesaml',
+        'database.password' => 'sdfsdf',
+    ],
+
+    'attrib_username' => 'urn:oid:1.3.6.1.4.1.23735.100.0',
+    'attrib_displayname' => 'urn:oid:2.5.4.3',
+
+    /* optional configuration parameters */
+
+    /* FIDO2 is phishing-resistent by binding generated credentials to a scope.
+     * Browsers will only invoke the registration/authentication if the scope
+     * matches the principal domain name the user is currently visiting.
+     * If not specified, the scope will be the hostname of the IdP as per
+     * its metadata. It is permissible to widen the scope up to the prinicpal
+     * domain though (e.g. authentication service is "saml.example.com" => scope
+     * can be extended to "example.com"; but not "examp1e.com". A registered
+     * FIDO2 token can then also be used on other servers in the same domain.
+     * If configuring this item, be sure that the authentication server name and
+     * the desired scope are a suffix match.
+     *
+     * If you do not control the entirety of your second-level domain, you must
+     * set the scope here explicitly to your own hostname to prevent some
+     * contrived attack scenarios with other servers in that same second-level
+     * domain.
+     */
+    'scope' => 'example.com',
+
+    /* the following will interactively ask the user if he is willing to share
+     * manufacturer and model information during credential registration.
+     * The user can decline, in which case registration will still succeed but
+     * vendor and model will be logged as "unknown model [unknown vendor]"
+     *
+     * When not requesting this, there is one less user interaction during the
+     * registration process; and no model information will be saved.
+     *
+     * defaults to "false"
+     */
+    'request_tokenmodel' => true,
+
+    /* should FIDO2 be enabled by default for all users? If not, users need to
+     * be white-listed in the database - other users simply pass through the
+     * filter without being subjected to 2FA.
+     *
+     * defaults to "disabled by default" === false
+     */
+    'default_enable' => false,
+
+    /* this parameter is used only if "use_database" is false. If the value of
+     * "force" is true then we trigger WebAuthn only if "attrib_toggle" from the
+     * user is not empty. If the value of "force" is false then we switch the value of
+     * "default_enable" only if "attrib_toggle" from the user is not empty.
+     * Default falue is true.
+     */
+    'force' => true,
+
+    /* this parameter stores the name of the attribute that is sent with user and which
+     * determines whether to trigger WebAuthn.
+     * Default value is 'toggle'
+     */
+    'attrib_toggle' => 'toggle',
+
+    /* this parameter determines if the database will be used to check
+     * whether to trigger second factor authentication or use the "attrib_toggle" instead.
+     * Default value of this attribute is true
+     */
+    'use_database' => true,
+
+    /* optional parameter which determines whether you will be able to register and manage tokens
+     * while authenticating or you want to use the standalone registration page for these
+     * purposes. If set to false => standalone registration page, if true => inflow registration.
+     * Defaults to true.
+     */
+    'use_inflow_registration' => true,
+
+    /* optional parameter that determines what auth source will be used in standalone registration page.
+     * Defaults to 'default-sp'.
+     */
+    'registration_auth_source' => 'default-sp',
+];

--- a/lib/Auth/Process/WebAuthn.php
+++ b/lib/Auth/Process/WebAuthn.php
@@ -13,69 +13,30 @@
 namespace SimpleSAML\Module\webauthn\Auth\Process;
 
 use SimpleSAML\Auth;
+use SimpleSAML\Configuration;
 use SimpleSAML\Error;
 use SimpleSAML\Logger;
 use SimpleSAML\Module;
 use SimpleSAML\Module\webauthn\Store;
+use SimpleSAML\Module\webauthn\WebAuthn\StaticProcessHelper;
 use SimpleSAML\Utils;
 
 class WebAuthn extends Auth\ProcessingFilter
 {
-    /**
-     * backend storage configuration. Required.
-     *
-     * @var \SimpleSAML\Module\webauthn\Store
-     */
-    private $store;
-
-    /**
-     * Scope of the FIDO2 attestation. Can only be in the own domain.
-     *
-     * @var string|null
-     */
-    private $scope = null;
-
-    /**
-     * The scope derived from the SimpleSAMLphp configuration;
-     * can be null due to misconfiguration, in case we cannot warn the administrator on a mismatching scope
-     *
-     * @var string|null
-     */
-    private $derivedScope = null;
-
-    /**
-     * attribute to use as username for the FIDO2 attestation.
-     *
-     * @var string
-     */
-    private $usernameAttrib;
-
-    /**
-     * attribute to use as display name for the FIDO2 attestation.
-     *
-     * @var string
-     */
-    private $displaynameAttrib;
-
-    /**
-     * @var boolean
-     */
-    private $requestTokenModel;
-
     /**
      * @var boolean should new users be considered as enabled by default?
      */
     private $defaultEnabled;
 
     /**
-     * @var boolean switch that determines how $toggle will be used, if true then value of $toggle
+     * @var boolean switch that determines how 'toggle' will be used, if true then value of 'toggle'
      *              will mean whether to trigger (true) or not (false) the webauthn authentication,
      *              if false then $toggle means whether to switch the value of $defaultEnabled and then use that
      */
     private $force;
 
     /**
-     * @var string an attribute which is associated with $force because it determines its meaning,
+     * @var string an attribute which is associated with 'force' because it determines its meaning,
      *              it either simply means whether to trigger webauthn authentication or switch the default settings,
      *              if null (was not sent as attribute) then the information from database is used
      */
@@ -90,6 +51,13 @@ class WebAuthn extends Auth\ProcessingFilter
      * @var string|null AuthnContextClassRef
      */
     private $authnContextClassRef = null;
+
+    /**
+     * An object with all the parameters that will be needed in the process
+     *
+     * @var Module\webauthn\WebAuthn\StateData
+     */
+    private $stateData;
 
     /**
      * Initialize filter.
@@ -110,8 +78,11 @@ class WebAuthn extends Auth\ProcessingFilter
         assert(is_array($config));
         parent::__construct($config, $reserved);
 
+        $this->stateData = new Module\webauthn\WebAuthn\StateData();
+
+        $moduleConfig = Configuration::getOptionalConfig('module_webauthn.php')->toArray();
         try {
-            $this->store = Store::parseStoreConfig($config['store']);
+            $this->stateData->store = Store::parseStoreConfig($moduleConfig['store']);
         } catch (\Exception $e) {
             Logger::error(
                 'webauthn: Could not create storage: ' .
@@ -120,58 +91,62 @@ class WebAuthn extends Auth\ProcessingFilter
         }
 
         // Set the optional scope if set by configuration
-        if (array_key_exists('scope', $config)) {
-            $this->scope = $config['scope'];
+        if (array_key_exists('scope', $moduleConfig)) {
+            $this->stateData->scope = $moduleConfig['scope'];
         }
 
         // Set the derived scope so we can compare it to the sent host at a later point
         $baseurl = Utils\HTTP::getSelfHost();
         $hostname = parse_url($baseurl, PHP_URL_HOST);
         if ($hostname !== null) {
-            $this->derivedScope = $hostname;
+            $this->stateData->derivedScope = $hostname;
         }
 
-        if (array_key_exists('attrib_username', $config)) {
-            $this->usernameAttrib = $config['attrib_username'];
+        if (array_key_exists('attrib_username', $moduleConfig)) {
+            $this->stateData->usernameAttrib = $moduleConfig['attrib_username'];
         } else {
             throw new Error\CriticalConfigurationError('webauthn: it is required to set attrib_username in config.');
         }
 
-        if (array_key_exists('attrib_displayname', $config)) {
-            $this->displaynameAttrib = $config['attrib_displayname'];
+        if (array_key_exists('attrib_displayname', $moduleConfig)) {
+            $this->stateData->displaynameAttrib = $moduleConfig['attrib_displayname'];
         } else {
             throw new Error\CriticalConfigurationError('webauthn: it is required to set attrib_displayname in config.');
         }
 
-        if (array_key_exists('request_tokenmodel', $config)) {
-            $this->requestTokenModel = $config['request_tokenmodel'];
+        if (array_key_exists('request_tokenmodel', $moduleConfig)) {
+            $this->stateData->requestTokenModel = $moduleConfig['request_tokenmodel'];
         } else {
-            $this->requestTokenModel = false;
+            $this->stateData->requestTokenModel = false;
         }
-        if (array_key_exists('default_enable', $config)) {
-            $this->defaultEnabled = $config['default_enable'];
+        if (array_key_exists('default_enable', $moduleConfig)) {
+            $this->defaultEnabled = $moduleConfig['default_enable'];
         } else {
             $this->defaultEnabled = false;
         }
 
-        if (array_key_exists('force', $config)) {
-            $this->force = $config['force'];
+        if (array_key_exists('force', $moduleConfig)) {
+            $this->force = $moduleConfig['force'];
         } else {
             $this->force = true;
         }
-        if (array_key_exists('attrib_toggle', $config)) {
-            $this->toggleAttrib = $config['attrib_toggle'];
+        if (array_key_exists('attrib_toggle', $moduleConfig)) {
+            $this->toggleAttrib = $moduleConfig['attrib_toggle'];
         } else {
             $this->toggleAttrib = 'toggle';
         }
-        if (array_key_exists('use_database', $config)) {
-            $this->useDatabase = $config['use_database'];
+        if (array_key_exists('use_database', $moduleConfig)) {
+            $this->useDatabase = $moduleConfig['use_database'];
         } else {
             $this->useDatabase = true;
         }
-        if (array_key_exists('authnContextClassRef', $config)) {
-            $this->authnContextClassRef = $config['authnContextClassRef'];
-
+        if (array_key_exists('authnContextClassRef', $moduleConfig)) {
+            $this->authnContextClassRef = $moduleConfig['authnContextClassRef'];
+        }
+        if (array_key_exists('use_inflow_registration', $moduleConfig)) {
+            $this->stateData->useInflowRegistration = $moduleConfig['use_inflow_registration'];
+        } else {
+            $this->stateData->useInflowRegistration = true;
         }
     }
 
@@ -198,25 +173,21 @@ class WebAuthn extends Auth\ProcessingFilter
         assert(array_key_exists('metadata-set', $state['Destination']));
         assert(array_key_exists('entityid', $state['Source']));
         assert(array_key_exists('metadata-set', $state['Source']));
-
-        if (!array_key_exists($this->usernameAttrib, $state['Attributes'])) {
+        if (!array_key_exists($this->stateData->usernameAttrib, $state['Attributes'])) {
             Logger::warning('webauthn: cannot determine if user needs second factor, missing attribute "' .
-                $this->usernameAttrib . '".');
+                $this->stateData->usernameAttrib . '".');
             return;
         }
 
-        $state['requestTokenModel'] = $this->requestTokenModel;
-        $state['webauthn:store'] = $this->store;
         $state['saml:AuthnContextClassRef'] = $this->authnContextClassRef ?? 'urn:rsa:names:tc:SAML:2.0:ac:classes:FIDO';
-
-        Logger::debug('webauthn: userid: ' . $state['Attributes'][$this->usernameAttrib][0]);
+        Logger::debug('webauthn: userid: ' . $state['Attributes'][$this->stateData->usernameAttrib][0]);
 
         $localToggle = !empty($state['Attributes'][$this->toggleAttrib])
             && !empty($state['Attributes'][$this->toggleAttrib][0]);
 
         if (
-            $this->store->is2FAEnabled(
-                $state['Attributes'][$this->usernameAttrib][0],
+            $this->stateData->store->is2FAEnabled(
+                $state['Attributes'][$this->stateData->usernameAttrib][0],
                 $this->defaultEnabled,
                 $this->useDatabase,
                 $localToggle,
@@ -226,19 +197,7 @@ class WebAuthn extends Auth\ProcessingFilter
             // nothing to be done here, end authprocfilter processing
             return;
         }
-
-        $state['FIDO2Tokens'] = $this->store->getTokenData($state['Attributes'][$this->usernameAttrib][0]);
-        $state['FIDO2Scope'] = $this->scope;
-        $state['FIDO2DerivedScope'] = $this->derivedScope;
-        $state['FIDO2Username'] = $state['Attributes'][$this->usernameAttrib][0];
-        $state['FIDO2Displayname'] = $state['Attributes'][$this->displaynameAttrib][0];
-        $state['FIDO2SignupChallenge'] = hash('sha512', random_bytes(64));
-        $state['FIDO2WantsRegister'] = false;
-        $state['FIDO2AuthSuccessful'] = false;
-
-        // Save state and redirect
-        $id = Auth\State::saveState($state, 'webauthn:request');
-        $url = Module::getModuleURL('webauthn/webauthn.php');
-        Utils\HTTP::redirectTrustedURL($url, ['StateId' => $id]);
+        StaticProcessHelper::prepareState($this->stateData, $state);
+        StaticProcessHelper::saveStateAndRedirect($state);
     }
 }

--- a/lib/WebAuthn/StateData.php
+++ b/lib/WebAuthn/StateData.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace SimpleSAML\Module\webauthn\WebAuthn;
+
+class StateData
+{
+    /**
+     * backend storage configuration. Required.
+     *
+     * @var \SimpleSAML\Module\webauthn\Store
+     */
+    public $store;
+
+    /**
+     * Scope of the FIDO2 attestation. Can only be in the own domain.
+     *
+     * @var string|null
+     */
+    public $scope = null;
+
+    /**
+     * The scope derived from the SimpleSAMLphp configuration;
+     * can be null due to misconfiguration, in case we cannot warn the administrator on a mismatching scope
+     *
+     * @var string|null
+     */
+    public $derivedScope = null;
+
+    /**
+     * attribute to use as username for the FIDO2 attestation.
+     *
+     * @var string
+     */
+    public $usernameAttrib;
+
+    /**
+     * attribute to use as display name for the FIDO2 attestation.
+     *
+     * @var string
+     */
+    public $displaynameAttrib;
+
+    /**
+     * @var boolean
+     */
+    public $requestTokenModel;
+
+    /**
+     * @var bool an attribute which determines whether you will be able to register and manage tokens
+     *           while authenticating or you want to use the standalone registration page for these
+     *           purposes. If set to false => standalone registration page, if true => inflow registration.
+     *           Defaults to true.
+     */
+    public $useInflowRegistration;
+}

--- a/lib/WebAuthn/StaticProcessHelper.php
+++ b/lib/WebAuthn/StaticProcessHelper.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace SimpleSAML\Module\webauthn\WebAuthn;
+
+use SimpleSAML\Auth;
+use SimpleSAML\Module;
+use SimpleSAML\Utils;
+
+class StaticProcessHelper
+{
+    public static function saveStateAndRedirect(&$state)
+    {
+        $id = Auth\State::saveState($state, 'webauthn:request');
+        $url = Module::getModuleURL('webauthn/webauthn.php');
+        Utils\HTTP::redirectTrustedURL($url, ['StateId' => $id]);
+    }
+
+    public static function prepareState($stateData, &$state)
+    {
+        $state['requestTokenModel'] = $stateData->requestTokenModel;
+        $state['webauthn:store'] = $stateData->store;
+        $state['FIDO2Tokens'] = $stateData->store->getTokenData($state['Attributes'][$stateData->usernameAttrib][0]);
+        $state['FIDO2Scope'] = $stateData->scope;
+        $state['FIDO2DerivedScope'] = $stateData->derivedScope;
+        $state['FIDO2Username'] = $state['Attributes'][$stateData->usernameAttrib][0];
+        $state['FIDO2Displayname'] = $state['Attributes'][$stateData->displaynameAttrib][0];
+        $state['FIDO2SignupChallenge'] = hash('sha512', random_bytes(64));
+        $state['FIDO2WantsRegister'] = false;
+        $state['FIDO2AuthSuccessful'] = false;
+        $state['UseInflowRegistration'] = $stateData->useInflowRegistration;
+    }
+}

--- a/templates/authentication.twig
+++ b/templates/authentication.twig
@@ -1,0 +1,25 @@
+{% set pagetitle = '{webauthn:webauthn:page_title}'|trans %}
+{% extends "base.twig" %}
+
+{% block preload %}
+    <link rel="stylesheet" type="text/css" href="{{ asset('css/webauthn.css', 'webauthn') }}" />
+    <meta name="frontendData" id="frontendData" content="{{ frontendData }}" />
+{% endblock %}
+
+{% block content %}
+    <h1>{{ '{webauthn:webauthn:heading1}'|trans }}</h1>
+    {% if authURL|length > 0 %}
+        <form id='authform' method='POST' action='{{ authURL|raw }}'>
+            <input type='hidden' id='resp' name='response_id' value='0'/>
+            <input type='hidden' id='data' name='attestation_client_data_json' value='nix'/>
+            <input type='hidden' id='authdata' name='authenticator_data' value='mehrnix'/>
+            <input type='hidden' id='sigdata' name='signature' value='evenmorenix'/>
+            <input type='hidden' id='data_raw_b64' name='client_data_raw' value='garnix'/>
+            <input type='hidden' id='type' name='type' value='something'/>
+            <input type='hidden' id='operation' name='operation' value='AUTH'/>
+            <button type='button' id='authformSubmit'>{{ '{webauthn:webauthn:authTokenButton}'|trans }}</button>
+        </form>
+    {% endif %}
+    <script src="{{ asset('js/webauthn.js', 'webauthn') }}"></script>
+    <script src="{{ asset('js/authentication.js', 'webauthn') }}"></script>
+{% endblock %}

--- a/templates/webauthn.twig
+++ b/templates/webauthn.twig
@@ -47,12 +47,14 @@
                     </form>
                 {% endif %}
             {% endfor %}
-            <div class='space'></div>
-            <form id='nevermind' method='POST' action='{{ delURL|raw }}'>
-                <button type='submit' id='submit-nevermind' name='submit' value='NEVERMIND'>
-                    {{ '{webauthn:webauthn:noChange}'|trans }}
-                </button>
-            </form>
+            {% if showExitButton %}
+                <div class='space'></div>
+                <form id='nevermind' method='POST' action='{{ delURL|raw }}'>
+                    <button type='submit' id='submit-nevermind' name='submit' value='NEVERMIND'>
+                        {{ '{webauthn:webauthn:noChange}'|trans }}
+                    </button>
+                </form>
+            {% endif %}
         {% endif %}
     {% endif %}
     {% if authURL|length > 0 %}

--- a/www/assets/js/authentication.js
+++ b/www/assets/js/authentication.js
@@ -1,0 +1,5 @@
+function authenticate() {
+    setTimeout(function() {document.getElementById("authformSubmit").click();}, 500)
+}
+
+window.addEventListener('DOMContentLoaded', authenticate);

--- a/www/managetoken.php
+++ b/www/managetoken.php
@@ -5,6 +5,9 @@ use SimpleSAML\Auth;
 use SimpleSAML\Configuration;
 use SimpleSAML\Error as SspError;
 use SimpleSAML\Logger;
+use SimpleSAML\Module\webauthn\WebAuthn\StaticProcessHelper;
+use SimpleSAML\Utils;
+use SimpleSAML\Module;
 
 if (session_status() != PHP_SESSION_ACTIVE) {
     session_cache_limiter('nocache');
@@ -35,7 +38,18 @@ switch ($_POST['submit']) {
         }
         $store = $state['webauthn:store'];
         $store->deleteTokenData($_POST['credId']);
-        Auth\ProcessingChain::resumeProcessing($state);
+        if (array_key_exists('Registration', $state)) {
+            foreach ($state['FIDO2Tokens'] as $key => $value) {
+                if ($state['FIDO2Tokens'][$key][0] == $_POST['credId']) {
+                    unset($state['FIDO2Tokens'][$key]);
+                    break;
+                }
+            }
+
+            StaticProcessHelper::saveStateAndRedirect($state);
+        } else {
+            Auth\ProcessingChain::resumeProcessing($state);
+        }
         break;
     default:
         throw new Exception("Unknown submit button state.");

--- a/www/registration.php
+++ b/www/registration.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * construct relevant page variables for FIDO registration, authentication and
+ * token management
+ *
+ * @package SimpleSAMLphp
+ */
+
+use SimpleSAML\Auth\Simple;
+use SimpleSAML\Configuration;
+use SimpleSAML\Logger;
+use SimpleSAML\Metadata\MetaDataStorageHandler;
+use SimpleSAML\Module\webauthn\Store;
+use SimpleSAML\Module\webauthn\WebAuthn\StateData;
+use SimpleSAML\Module\webauthn\WebAuthn\StaticProcessHelper;
+use SimpleSAML\Utils;
+use Webmozart\Assert\Assert;
+
+$config = Configuration::getOptionalConfig('module_webauthn.php');
+$registrationAuthSource = $config->getString('registration_auth_source', 'default-sp');
+
+$as = new Simple($registrationAuthSource);
+$stateData = new StateData();
+$as->requireAuth();
+$attrs = $as->getAttributes();
+
+$state['Attributes'] = $attrs;
+
+$stateData->requestTokenModel = $config->getBoolean('request_tokenmodel', false);
+try {
+    $stateData->store = Store::parseStoreConfig($config->getArray('store'));
+} catch (\Exception $e) {
+    Logger::error(
+        'webauthn: Could not create storage: ' .
+        $e->getMessage()
+    );
+}
+$stateData->scope = $config->getString('scope', null);
+$baseurl = Utils\HTTP::getSelfHost();
+$hostname = parse_url($baseurl, PHP_URL_HOST);
+if ($hostname !== null) {
+    $stateData->derivedScope = $hostname;
+}
+$stateData->usernameAttrib = $config->getString('attrib_username');
+$stateData->displaynameAttrib = $config->getString('attrib_displayname');
+$stateData->useInflowRegistration = true;
+
+StaticProcessHelper::prepareState($stateData, $state);
+
+$metadataHandler = MetaDataStorageHandler::getMetadataHandler();
+$metadata = $metadataHandler->getMetaDataCurrent('saml20-idp-hosted');
+$state['Source'] = $metadata;
+$state['IdPMetadata'] = $metadata;
+$state['Registration'] = true;
+$state['FIDO2AuthSuccessful'] = $state['FIDO2Tokens'][0][0];
+$state['FIDO2WantsRegister'] = true;
+
+StaticProcessHelper::saveStateAndRedirect($state);

--- a/www/webauthn.php
+++ b/www/webauthn.php
@@ -30,8 +30,10 @@ $id = $_REQUEST['StateId'];
 /** @var array $state */
 $state = Auth\State::loadState($id, 'webauthn:request');
 
+$templateFile = $state['UseInflowRegistration'] ? 'webauthn:webauthn.php' : 'webauthn:authentication.twig';
+
 // Make, populate and layout consent form
-$t = new Template($globalConfig, 'webauthn:webauthn.php');
+$t = new Template($globalConfig, $templateFile);
 $translator = $t->getTranslator();
 $t->data['UserID'] = $state['FIDO2Username'];
 $t->data['FIDO2Tokens'] = $state['FIDO2Tokens'];
@@ -66,9 +68,10 @@ $frontendData = [];
 $frontendData['challengeEncoded'] = $challengeEncoded;
 $frontendData['state'] = [];
 foreach (['Source', 'FIDO2Scope','FIDO2Username','FIDO2Displayname','requestTokenModel'] as $stateItem) {
-    Assert::string($state[$stateItem]);
     $frontendData['state'][$stateItem] = $state[$stateItem];
 }
+
+$t->data['showExitButton'] = !array_key_exists('Registration', $state);
 $frontendData['usernameEncoded'] = $usernameEncoded;
 $frontendData['attestation'] = $state['requestTokenModel'] ? "indirect" : "none";
 $frontendData['credentialIdEncoded'] = $credentialIdEncoded;


### PR DESCRIPTION
* new mode in which the webauthn module can be run has been created

* there is a new page www/registration.php which can be used for managing tokens instead of the inflow registration

* details have been added to the README.md file and to the comments

* configuration has been moved to module_config.php