### PR TITLE
fix: get string from stream if needed

### DIFF
--- a/src/Controller/AuthProcess.php
+++ b/src/Controller/AuthProcess.php
@@ -155,6 +155,10 @@ class AuthProcess
                 "User attempted to authenticate with an unknown credential ID. This should already have been prevented by the browser!"
             );
         }
+        
+        if (!is_string($oneToken[1])) {
+            $oneToken[1] = stream_get_contents($oneToken[1]);
+        }
 
         /** @psalm-var array $oneToken */
         $authObject = new WebAuthnAuthenticationEvent(


### PR DESCRIPTION
WebAuthnAuthenticationEvent expects a string, not a stream