### PR TITLE
Convert credential resource if necessary (postgres uses bytea)

### DIFF
--- a/src/WebAuthn/Store/Database.php
+++ b/src/WebAuthn/Store/Database.php
@@ -304,6 +304,9 @@ class Database extends Store
         );
 
         while ($row = $st->fetch(PDO::FETCH_NUM)) {
+            if(is_resource($row[1])){
+                $row[1] = stream_get_contents($row[1]);
+            }
             $ret[] = $row;
         }
 


### PR DESCRIPTION
When using postgres the credential is stored as a bytea, which doesn't serialize nicely without calling stream_get_contents() first. This checks for if it is a resource and calls stream_get_contents() before returning in the getTokenData function.