### PR TITLE
Don't show Remove button until MFA is complete

### DIFF
--- a/templates/webauthn.twig
+++ b/templates/webauthn.twig
@@ -16,12 +16,14 @@
                 {% for token in FIDO2Tokens %}
                     {% if FIDO2AuthSuccessful == false or FIDO2AuthSuccessful != token.0 %}
                         <li class='othertoken'><img class='factorlogo' src='{{ asset('base/icons/2nd.png', 'webauthn') }}' alt='2nd'/>{% if token.5 == 4 and token.6 == true %}<img class='factorlogo' src='{{ asset('base/icons/pwless.png', 'webauthn') }}' alt='Passwordless'/>{% else %}<img class='factorlogo' src='{{ asset('base/icons/nothing.png', 'webauthn') }}' alt='Password-based only'/>{%  endif  %}{{ token.3|e }}&nbsp;
-                        <form class='{% if token.6 == true %}form-discoverable-credential{% else %}deleteform{% endif %}' id='delete-{{ loop.index }}' method='POST' action='{{ delURL|raw }}'>
-                        <input type='hidden' id='credId-{{ loop.index }}' name='credId' value='{{ token.0 }}'/>
-                        <button type='submit' id='submit-{{ loop.index }}' name='submit' value='DELETE'>
-                            {{ '{webauthn:webauthn:removePrefix}'|trans }}
-                        </button>
-                    </form>
+                        {% if FIDO2AuthSuccessful == true %}
+                            <form class='{% if token.6 == true %}form-discoverable-credential{% else %}deleteform{% endif %}' id='delete-{{ loop.index }}' method='POST' action='{{ delURL|raw }}'>
+                                <input type='hidden' id='credId-{{ loop.index }}' name='credId' value='{{ token.0 }}'/>
+                                <button type='submit' id='submit-{{ loop.index }}' name='submit' value='DELETE'>
+                                    {{ '{webauthn:webauthn:removePrefix}'|trans }}
+                                </button>
+                            </form>
+                        {% endif %}
                         </li>
                     {% else %}
                         <li class='currenttoken'>{{ token.3|e }}{% if token.5 == 4 and token.6 == true %} <font color='red'>PasswordlessCapable</font> {%  endif  %} {{ '{webauthn:webauthn:currentToken}'|trans }}</li>


### PR DESCRIPTION
After initial authentication, clicking the Remove button before MFA completion would throw an error. 

Hiding the button until then will prevent this error.