### PR TITLE
Fix PHP Warning:  Trying to access array offset on null

### DIFF
--- a/src/Controller/RegProcess.php
+++ b/src/Controller/RegProcess.php
@@ -166,7 +166,7 @@ class RegProcess
             count(json_decode($request->request->get('clientext'), true)) > 0
         ) {
             $extensions = json_decode($request->request->get('clientext'), true);
-            if ($extensions['credProps']['rk'] === true) {
+            if (isset($extensions['credProps']['rk']) && $extensions['credProps']['rk'] === true) {
                 $isResidentKey = 1;
             }
         }


### PR DESCRIPTION
I'm assuming the array key doesn't exist when not using a resident key