### PR TITLE
Exception error message if misconfigured password authsource

### DIFF
--- a/src/Controller/PushbackUserPass.php
+++ b/src/Controller/PushbackUserPass.php
@@ -85,7 +85,11 @@ class PushbackUserPass
 
         $authsources = Configuration::getConfig('authsources.php')->toArray();
         $authsourceString = $state['pushbackAuthsource'];
-        $classname = get_class(Auth\Source::getById($authsourceString));
+        $authsourceClass = Auth\Source::getById($authsourceString);
+        if (is_null($authsourceClass)) {
+            throw new Exception("password authsource not found");
+        }
+        $classname = get_class($authsourceClass);
         class_alias($classname, '\SimpleSAML\Module\webauthn\Auth\Source\AuthSourceOverloader');
         $overrideSource = new class (
             ['AuthId' => $authsourceString],


### PR DESCRIPTION
Exception error message if misconfigured password authsource, instead of:

`TypeError: get_class(): Argument #1 ($object) must be of type object, null given`