### PR TITLE
FIDO2Tokens variable as indexed array after remove token

### DIFF
--- a/src/Controller/ManageToken.php
+++ b/src/Controller/ManageToken.php
@@ -107,6 +107,7 @@ class ManageToken
                     foreach ($state['FIDO2Tokens'] as $key => $value) {
                         if ($state['FIDO2Tokens'][$key][0] == $credId) {
                             unset($state['FIDO2Tokens'][$key]);
+                            $state['FIDO2Tokens'] = array_values($state['FIDO2Tokens']);
                             break;
                         }
                     }


### PR DESCRIPTION
When the first operation in Registration Page is  remove a token, FIDO2Tokens state variable is transformed from indexed array to associative array. Later, FIDO2Tokens is used to write a json variable (src/Controller/WebAuthn.php line 226, $t->data['frontendData'] = json_encode($frontendData);)

That breaks the javascript webauthn.js 'publicKeyCredentialRequestOptions' variable.