### PR TITLE
Fix user getting pushed to required userVerification

### DIFF
--- a/public/assets/js/webauthn.js
+++ b/public/assets/js/webauthn.js
@@ -212,10 +212,10 @@ window.addEventListener('DOMContentLoaded', () => {
     }
     let authform = document.getElementById('authform');
     if (authform !== null) {
-        if (frontendData['FIDO2PasswordlessAuthMode'] === false) {
-            document.getElementById('authformSubmit').addEventListener('click', authButtonClick);
-        } else {
+        if (frontendData['FIDO2PasswordlessAuthMode'] === true) {
             document.getElementById('authformSubmit').addEventListener('click', passwordlessAuthButtonClick);
+        } else {
+            document.getElementById('authformSubmit').addEventListener('click', authButtonClick);
         }
         authform.addEventListener('submit', () => false);
     }


### PR DESCRIPTION
Fix unexpected requirement of users to use more strict passwordless auth requirements

I think this would happen when the user already has a session and then the webauthn module is enabled.